### PR TITLE
Implement Vimsottari Dasha calculations

### DIFF
--- a/lib/src/panchanga_models.dart
+++ b/lib/src/panchanga_models.dart
@@ -323,6 +323,37 @@ Moonset: $moonsetString
   }
 }
 
+/// Represents a single Vimsottari Dasha period
+class DashaPeriod {
+  final int planet; // Index into PanchangaConstants.planetList
+  final String planetName;
+  final DateTime startDate;
+  final DateTime endDate;
+
+  DashaPeriod({
+    required this.planet,
+    required this.planetName,
+    required this.startDate,
+    required this.endDate,
+  });
+
+  @override
+  String toString() {
+    final start = startDate.toString().split(' ')[0];
+    final end = endDate.toString().split(' ')[0];
+    return 'Dasha: $planetName ($start - $end)';
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'planet': planet,
+      'planetName': planetName,
+      'startDate': startDate.toIso8601String(),
+      'endDate': endDate.toIso8601String(),
+    };
+  }
+}
+
 /// Planet position information
 class PlanetPosition {
   final int planet;

--- a/lib/src/panchanga_service.dart
+++ b/lib/src/panchanga_service.dart
@@ -614,6 +614,65 @@ class PanchangaService {
     }
   }
 
+  /// Calculate Vimsottari Dasha periods from a birth date
+  /// @param birthJd: Julian Day Number of the birth moment
+  /// @param birthPlace: Place of birth (used for timezone)
+  /// @return: List of 9 DashaPeriod objects covering the full 120-year cycle
+  static List<DashaPeriod> vimsottariDasha(double birthJd, Place birthPlace) {
+    try {
+      final jdUtc = birthJd - birthPlace.timezone / 24;
+      final moonLong = lunarLongitude(jdUtc);
+
+      // Determine birth nakshatra (1-27) and degrees traversed within it
+      final nakData = nakshatraPada(moonLong);
+      final nakNum = nakData[0] as int; // 1-based
+      final remainder = nakData[2] as double; // degrees traversed in nakshatra
+
+      const oneStar = 360.0 / 27;
+      final elapsedFraction = remainder / oneStar;
+
+      // Lord of the birth nakshatra: cycles through adhipatiList every 9 nakshatras
+      final dashStartIndex = (nakNum - 1) % 9;
+
+      // Convert birth JD to DateTime (date only)
+      final birthDateInfo = PanchangaUtils.jdToGregorian(birthJd);
+      final birthDate = DateTime(
+        birthDateInfo[0] as int,
+        birthDateInfo[1] as int,
+        birthDateInfo[2] as int,
+      );
+
+      final periods = <DashaPeriod>[];
+      DateTime currentDate = birthDate;
+
+      for (int i = 0; i < 9; i++) {
+        final seqIndex = (dashStartIndex + i) % 9;
+        final planet = PanchangaConstants.adhipatiList[seqIndex];
+        final totalYears =
+            PanchangaConstants.vimsottariDhasa[planet]!.toDouble();
+
+        // First dasha: only the remaining fraction; subsequent dashas: full period
+        final years = (i == 0) ? totalYears * (1.0 - elapsedFraction) : totalYears;
+
+        final days = (years * PanchangaConstants.tropicalYear).round();
+        final endDate = currentDate.add(Duration(days: days));
+
+        periods.add(DashaPeriod(
+          planet: planet,
+          planetName: PanchangaConstants.planetNames[planet],
+          startDate: currentDate,
+          endDate: endDate,
+        ));
+
+        currentDate = endDate;
+      }
+
+      return periods;
+    } catch (e) {
+      throw Exception('Failed to calculate vimsottari dasha: $e');
+    }
+  }
+
   /// Helper: Calculate daily moon speed
   static double _dailyMoonSpeed(double jd, Place place) {
     final jdUtc = jd - place.timezone / 24;

--- a/test/vedic_panchanga_dart_test.dart
+++ b/test/vedic_panchanga_dart_test.dart
@@ -241,6 +241,74 @@ void main() {
     });
   });
 
+  group('Vimsottari Dasha', () {
+    test('returns exactly 9 dasha periods', () {
+      // Use a known birth datetime: Jan 1, 1990, noon IST, Chennai
+      final birthJd = PanchangaUtils.gregorianToJd(1990, 1, 1, hour: 12.0);
+      final dashas = PanchangaService.vimsottariDasha(birthJd, chennai);
+      expect(dashas.length, equals(9));
+    });
+
+    test('dasha periods total at most 120 tropical years', () {
+      final birthJd = PanchangaUtils.gregorianToJd(1990, 1, 1, hour: 12.0);
+      final dashas = PanchangaService.vimsottariDasha(birthJd, chennai);
+
+      final firstStart = dashas.first.startDate;
+      final lastEnd = dashas.last.endDate;
+      final totalDays = lastEnd.difference(firstStart).inDays;
+      // First dasha is shortened (birth mid-cycle), so total < 120 years
+      // Minimum is 120 - max_dasha_years (Venus=20) = 100 years
+      final maxDays = (120 * 365.242190).round() + 2;
+      final minDays = (100 * 365.242190).round();
+      expect(totalDays, lessThanOrEqualTo(maxDays));
+      expect(totalDays, greaterThanOrEqualTo(minDays));
+    });
+
+    test('consecutive dasha periods are contiguous', () {
+      final birthJd = PanchangaUtils.gregorianToJd(1990, 1, 1, hour: 12.0);
+      final dashas = PanchangaService.vimsottariDasha(birthJd, chennai);
+
+      for (int i = 0; i < dashas.length - 1; i++) {
+        expect(dashas[i].endDate, equals(dashas[i + 1].startDate));
+      }
+    });
+
+    test('first dasha start matches birth date', () {
+      final birthJd = PanchangaUtils.gregorianToJd(1990, 1, 1, hour: 12.0);
+      final dashas = PanchangaService.vimsottariDasha(birthJd, chennai);
+
+      expect(dashas.first.startDate, equals(DateTime(1990, 1, 1)));
+    });
+
+    test('all planet names are non-empty strings', () {
+      final birthJd = PanchangaUtils.gregorianToJd(1990, 1, 1, hour: 12.0);
+      final dashas = PanchangaService.vimsottariDasha(birthJd, chennai);
+
+      for (final dasha in dashas) {
+        expect(dasha.planetName, isNotEmpty);
+      }
+    });
+
+    test('DashaPeriod toString includes planet name and dates', () {
+      final birthJd = PanchangaUtils.gregorianToJd(1990, 1, 1, hour: 12.0);
+      final dashas = PanchangaService.vimsottariDasha(birthJd, chennai);
+      final str = dashas.first.toString();
+      expect(str, contains(dashas.first.planetName));
+      expect(str, contains('Dasha:'));
+    });
+
+    test('DashaPeriod toJson returns correct fields', () {
+      final birthJd = PanchangaUtils.gregorianToJd(1990, 1, 1, hour: 12.0);
+      final dashas = PanchangaService.vimsottariDasha(birthJd, chennai);
+      final json = dashas.first.toJson();
+
+      expect(json['planet'], isNotNull);
+      expect(json['planetName'], isNotEmpty);
+      expect(json['startDate'], isNotNull);
+      expect(json['endDate'], isNotNull);
+    });
+  });
+
   group('Different Ayanamsas', () {
     test('different ayanamsas give different results', () {
       final jd = PanchangaUtils.gregorianToJd(2024, 10, 28);


### PR DESCRIPTION
Adds DashaPeriod model and PanchangaService.vimsottariDasha() method.
Given a birth Julian Day and place, calculates the 9-period Vimsottari
Dasha sequence using the moon's birth nakshatra and its position within
that nakshatra to determine the remaining fraction of the first dasha.

Constants (vimsottariDhasa, adhipatiList) were already in place; this
implements the calculation logic listed in the project roadmap.

https://claude.ai/code/session_0152N1wM8CwpKEPrDvkdQQPB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vimsottari Dasha calculations that generate a complete 9-period dasha cycle with planetary associations and precise start/end dates based on birth time and location.
  * Dasha periods support JSON serialization for external system integration.

* **Tests**
  * Added test coverage for Vimsottari Dasha calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->